### PR TITLE
change extension to .tscript

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
                     "TorqueScript"
                 ],
                 "extensions": [
-                    ".cs",
+                    ".tscript",
                     ".gui",
                     ".mis"
                 ],


### PR DESCRIPTION
Extension was changed and not 'added' because the justification for the extension change was the conflict between torquescript and C# dispite torque using the extension long before CSharp #endrant